### PR TITLE
Fix NullpointerException during StaticLayout creation

### DIFF
--- a/codeinputview/src/main/java/com/raycoarana/codeinputview/CodeInputView.java
+++ b/codeinputview/src/main/java/com/raycoarana/codeinputview/CodeInputView.java
@@ -383,7 +383,7 @@ public class CodeInputView extends View {
                     .build();
         } else {
             staticLayout = new StaticLayout(
-                    mErrorMessage,
+                    errorMessage,
                     textPaint,
                     textWidth,
                     alignment,


### PR DESCRIPTION
We're seeing this crash:
```java.lang.NullPointerException: Attempt to invoke interface method 'int java.lang.CharSequence.length()' on a null object reference
        at android.text.StaticLayout.<init>(StaticLayout.java:49)
        at com.raycoarana.codeinputview.CodeInputView.buildErrorTextLayout(SourceFile:385)
        at com.raycoarana.codeinputview.CodeInputView.onMeasure(SourceFile:430)
        at android.view.View.measure(View.java:17438)
        at androidx.constraintlayout.widget.ConstraintLayout.internalMeasureChildren(SourceFile:1212)
        at androidx.constraintlayout.widget.ConstraintLayout.onMeasure(SourceFile:1552)
        at android.view.View.measure(View.java:17438)
        at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:5464)
        at android.widget.FrameLayout.onMeasure(FrameLayout.java:430)
        at androidx.appcompat.widget.ContentFrameLayout.onMeasure(SourceFile:143)
        at android.view.View.measure(View.java:17438)
        at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:5464)
        at android.widget.FrameLayout.onMeasure(FrameLayout.java:430)
        at android.view.View.measure(View.java:17438)
        at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:5464)
        at android.widget.FrameLayout.onMeasure(FrameLayout.java:430)
        at android.view.View.measure(View.java:17438)
        at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:5464)
        at android.widget.LinearLayout.measureChildBeforeLayout(LinearLayout.java:1436)
        at android.widget.LinearLayout.measureVertical(LinearLayout.java:722)
        at android.widget.LinearLayout.onMeasure(LinearLayout.java:613)
        at android.view.View.measure(View.java:17438)
        at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:5464)
        at android.widget.FrameLayout.onMeasure(FrameLayout.java:430)
        at com.android.internal.policy.impl.PhoneWindow$DecorView.onMeasure(PhoneWindow.java:2560)
        at android.view.View.measure(View.java:17438)
        at android.view.ViewRootImpl.performMeasure(ViewRootImpl.java:2001)
        at android.view.ViewRootImpl.measureHierarchy(ViewRootImpl.java:1166)
        at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:1372)
        at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1054)
        at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:5786)
        at android.view.Choreographer$CallbackRecord.run(Choreographer.java:767)
        at android.view.Choreographer.doCallbacks(Choreographer.java:580)
        at android.view.Choreographer.doFrame(Choreographer.java:550)
        at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:753)
        at android.os.Handler.handleCallback(Handler.java:739)
        at android.os.Handler.dispatchMessage(Handler.java:95)
        at android.os.Looper.loop(Looper.java:135)
        at android.app.ActivityThread.main(ActivityThread.java:5221)
        at java.lang.reflect.Method.invoke(Method.java:-2)
        at java.lang.reflect.Method.invoke(Method.java:372)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:898)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:693)```

That seems caused by a null during the construction of the StaticLayout.

Since the null check was, already, being performed for the construction with the builder. I've replicated that in the else branch.