### PR TITLE
invalidating after removing a character

### DIFF
--- a/codeinputview/src/main/java/com/raycoarana/codeinputview/CodeInputView.java
+++ b/codeinputview/src/main/java/com/raycoarana/codeinputview/CodeInputView.java
@@ -873,6 +873,7 @@ public class CodeInputView extends View {
         if (canDelete) {
             int length = mSpannableSupportBuilder.length();
             mSpannableSupportBuilder.delete(length - 1, length);
+            invalidate();
         }
         return canDelete;
     }


### PR DESCRIPTION
Currently hitting backspace won't lead to redrawing, drawn state and StringBuilder will be out of sync.
Fixed this.